### PR TITLE
add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+❗❗❗ Deprecation Notice: Gatsby now let you configure trailing slash out of the box. See [documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/)
+
 # gatsby-plugin-force-trailing-slashes
 
 This plugin is one component of unifying a Gatsby site to _use_ trailing slashes. To correctly configure a Gatsby site to use trailing slashes, you need the following **three** pieces in place:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-❗❗❗ Deprecation Notice: Gatsby now let you configure trailing slash out of the box. See [documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/)
-
 # gatsby-plugin-force-trailing-slashes
+
+**Please Note:** This plugin will soon be deprecated, please use Gatsby's `trailingSlash` option. Read the [documentation](https://gatsby.dev/trailing-slash) to learn more.
 
 This plugin is one component of unifying a Gatsby site to _use_ trailing slashes. To correctly configure a Gatsby site to use trailing slashes, you need the following **three** pieces in place:
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,6 +23,6 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
 
 exports.onPreInit = ({ reporter }) => {
   reporter.warn(
-    `gatsby-plugin-force-trailing-slashes: Gatsby now let you configure trailing slash out of the box. See documentation https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/`
-  );
-};
+    `gatsby-plugin-remove-trailing-slashes: Gatsby now has a trailingSlash option. Learn more at https://gatsby.dev/trailing-slash`
+  )
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -20,3 +20,9 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
     resolve()
   })
 }
+
+exports.onPreInit = ({ reporter }) => {
+  reporter.warn(
+    `gatsby-plugin-force-trailing-slashes: Gatsby now let you configure trailing slash out of the box. See documentation https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/`
+  );
+};

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,6 +23,7 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
 
 exports.onPreInit = ({ reporter }) => {
   reporter.warn(
-    `gatsby-plugin-remove-trailing-slashes: Gatsby now has a trailingSlash option. Learn more at https://gatsby.dev/trailing-slash`
+    `gatsby-plugin-force-trailing-slashes: Gatsby now has a trailingSlash option. Learn more at https://gatsby.dev/trailing-slash`
+
   )
 }


### PR DESCRIPTION
## Description

Note: The documentation for trailing slash in Gatsby is not released yet. Ideally, we want to merge this after the docs is ready

Add deprecation notice since Gatsby now provides support for trailing slash config out of the box

## Documentation 

https://gatsby.dev/trailing-slash