### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### ‼️ HEADS UP:
 
-**This plugin will soon be deprecated**, please use Gatsby's new `trailingSlash` option. Read the [documentation](https://gatsby.dev/trailing-slash) to learn more.
+**This plugin will soon be deprecated**, please use Gatsby's new `trailingSlash` option. Read the [documentation](https://www.gatsbyjs.com/docs/reference/release-notes/v4.7/#trailingslash-option) to learn more.
 
 **NO FURTHER UPDATES TO THIS PLUGIN WILL BE SHIPPED**
 


### PR DESCRIPTION
The aim of this PR is to fix the broken link that points and leads to the trailing slash docs, changing essentially:

```diff
- https://gatsby.dev/trailing-slash
+ www.gatsbyjs.com/docs/reference/release-notes/v4.7/#trailingslash-option
```

Nothing more, nothing less.